### PR TITLE
fix broken link in section 5.1

### DIFF
--- a/notebooks/5.1_variational_quantum_eigensolver.ipynb
+++ b/notebooks/5.1_variational_quantum_eigensolver.ipynb
@@ -167,7 +167,7 @@
    "source": [
     "### ハミルトニアンを準備する\n",
     "\n",
-    "参考文献[1]の [Supplementary Information](https://media.nature.com/original/nature-assets/ncomms/2014/140723/ncomms5213/extref/ncomms5213-s1.pdf) の表から、H-He間の距離が$0.9$オングストロームの時のハミルトニアンの係数を読み取り、定義する。このハミルトニアンの最小エネルギー固有状態を求めれば、様々なH-He$^+$分子の性質を知ることができる。\n",
+    "参考文献[1]の [Supplementary Information](https://static-content.springer.com/esm/art%3A10.1038%2Fncomms5213/MediaObjects/41467_2014_BFncomms5213_MOESM1050_ESM.pdf) の表から、H-He間の距離が$0.9$オングストロームの時のハミルトニアンの係数を読み取り、定義する。このハミルトニアンの最小エネルギー固有状態を求めれば、様々なH-He$^+$分子の性質を知ることができる。\n",
     "\n",
     "※ このハミルトニアンは、電子-原子核間のクーロン相互作用および電子同士のクーロン相互作用の大きさから導かれている。詳細は第6章の量子化学計算に関する項で学ぶことになる。"
    ]


### PR DESCRIPTION
https://dojo.qulacs.org/ja/latest/notebooks/5.1_variational_quantum_eigensolver.html#%E3%83%8F%E3%83%9F%E3%83%AB%E3%83%88%E3%83%8B%E3%82%A2%E3%83%B3%E3%82%92%E6%BA%96%E5%82%99%E3%81%99%E3%82%8B 冒頭のリンクが（おそらくリンク先のURL変更により）無効なリンクになっています。

元々のリンクが意図していたリンク先と同じと思われるpdfに、リンク先を差し替えます。
https://www.nature.com/articles/ncomms5213#Sec16