### PR TITLE
Google Analytics (GA4) とCookieコンセントバナーの導入

### DIFF
--- a/_static/cookie-consent.css
+++ b/_static/cookie-consent.css
@@ -1,0 +1,63 @@
+#qnd-cookie-banner {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 10000;
+  background: rgba(0, 35, 55, 0.95);
+  color: #f0f0f0;
+  font-size: 14px;
+  line-height: 1.5;
+  box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.25);
+}
+
+.qnd-cookie-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 16px 24px;
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
+.qnd-cookie-msg {
+  margin: 0;
+  flex: 1 1 400px;
+}
+
+.qnd-cookie-buttons {
+  display: flex;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.qnd-cookie-btn {
+  border: none;
+  border-radius: 4px;
+  padding: 8px 20px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.2s ease;
+}
+
+.qnd-cookie-btn:hover {
+  opacity: 0.85;
+}
+
+.qnd-cookie-btn-accept {
+  background: #05c3a5;
+  color: #fff;
+}
+
+.qnd-cookie-btn-decline {
+  background: transparent;
+  color: #ccc;
+  border: 1px solid #666;
+}
+
+.qnd-cookie-btn-decline:hover {
+  color: #fff;
+  border-color: #999;
+}

--- a/_static/cookie-consent.js
+++ b/_static/cookie-consent.js
@@ -1,0 +1,49 @@
+document.addEventListener("DOMContentLoaded", function () {
+  // Already consented — nothing to show
+  if (document.cookie.indexOf("qnd_cookie_consent=accepted") !== -1) return;
+
+  // Detect language from <html lang="...">
+  var lang = (document.documentElement.lang || "ja").toLowerCase();
+  var isEn = lang.indexOf("en") === 0;
+
+  var msg = isEn
+    ? 'This site uses cookies (including Google Analytics) to improve your experience.'
+    : 'このサイトではGoogle Analyticsなどの目的でCookieを使用しています。';
+  var btnAccept = isEn ? 'Accept' : '同意する';
+  var btnDecline = isEn ? 'Decline' : '拒否する';
+
+  var banner = document.createElement("div");
+  banner.id = "qnd-cookie-banner";
+  banner.innerHTML =
+    '<div class="qnd-cookie-inner">' +
+      '<p class="qnd-cookie-msg">' + msg + '</p>' +
+      '<div class="qnd-cookie-buttons">' +
+        '<button id="qnd-cookie-accept" class="qnd-cookie-btn qnd-cookie-btn-accept">' + btnAccept + '</button>' +
+        '<button id="qnd-cookie-decline" class="qnd-cookie-btn qnd-cookie-btn-decline">' + btnDecline + '</button>' +
+      '</div>' +
+    '</div>';
+  document.body.appendChild(banner);
+
+  function setCookie(value) {
+    var expires = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toUTCString();
+    var secure = location.protocol === "https:" ? "; Secure" : "";
+    document.cookie = "qnd_cookie_consent=" + value + "; Path=/; Expires=" + expires + "; SameSite=Lax" + secure;
+  }
+
+  function closeBanner() {
+    banner.style.transition = "opacity 0.3s ease";
+    banner.style.opacity = "0";
+    setTimeout(function () { banner.remove(); }, 300);
+  }
+
+  document.getElementById("qnd-cookie-accept").addEventListener("click", function () {
+    setCookie("accepted");
+    closeBanner();
+    if (typeof qndLoadGA === "function") qndLoadGA();
+  });
+
+  document.getElementById("qnd-cookie-decline").addEventListener("click", function () {
+    setCookie("declined");
+    closeBanner();
+  });
+});

--- a/conf.py
+++ b/conf.py
@@ -87,6 +87,5 @@ if os.environ.get("READTHEDOCS", "") == "True":
     html_context["READTHEDOCS"] = True
 
 html_static_path = ['_static']
-html_js_files = ['sidebar-contact.js']     # ← 追加
-# # 任意: CSSも使うなら
-# html_css_files = ['custom.css']
+html_js_files = ['sidebar-contact.js', 'cookie-consent.js']
+html_css_files = ['cookie-consent.css']

--- a/sphinx_qndojo_theme/layout.html
+++ b/sphinx_qndojo_theme/layout.html
@@ -1,2 +1,14 @@
 {% extends "sphinx_rtd_theme/layout.html" %}
 {% set favicon = 'empty.ico' %}
+
+{% block extrahead %}
+<!-- Google Analytics (GA4) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-PXKC2GPZF1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-PXKC2GPZF1');
+</script>
+{{ super() }}
+{% endblock %}

--- a/sphinx_qndojo_theme/layout.html
+++ b/sphinx_qndojo_theme/layout.html
@@ -2,13 +2,24 @@
 {% set favicon = 'empty.ico' %}
 
 {% block extrahead %}
-<!-- Google Analytics (GA4) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-PXKC2GPZF1"></script>
+<!-- GA4: loaded only after cookie consent -->
 <script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-PXKC2GPZF1');
+  var QND_GA_ID = 'G-PXKC2GPZF1';
+  function qndLoadGA() {
+    if (document.querySelector('script[src*="googletagmanager"]')) return;
+    var s = document.createElement('script');
+    s.async = true;
+    s.src = 'https://www.googletagmanager.com/gtag/js?id=' + QND_GA_ID;
+    document.head.appendChild(s);
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', QND_GA_ID);
+  }
+  // Auto-load if already consented
+  if (document.cookie.indexOf('qnd_cookie_consent=accepted') !== -1) {
+    qndLoadGA();
+  }
 </script>
 {{ super() }}
 {% endblock %}


### PR DESCRIPTION
## Summary
- GA4 (G-PXKC2GPZF1) を全ページに導入
- Cookieコンセントバナーを追加（日英対応）
- ユーザーが同意するまでGA4スクリプトをブロック（GDPR対応）

## Test plan
- [x] 初回訪問時にCookieバナーが表示されることを確認
- [x] 「同意する」クリック後にGA4が読み込まれることを確認
- [x] 「拒否する」クリック後にGA4がブロックされたままであることを確認
- [x] 再訪問時にバナーが表示されないことを確認
- [x] 日本語ページで日本語バナーが表示されることを確認